### PR TITLE
Add experimental webm support

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,6 +100,8 @@ func main() {
 		router.GET("/movies/:name/at/:at/1.jpg", movieHandler(ms, "jpg"))
 		router.GET("/movies/:name/at/:at/1.gif",
 			cache.CachePage(store, 365*24*time.Hour, movieHandler(ms, "gif")))
+		router.GET("/movies/:name/at/:at/1.webm",
+			cache.CachePage(store, 365*24*time.Hour, movieHandler(ms, "webm")))
 		router.GET("/movies/:name/all.html",
 			cache.CachePage(store, 365*24*time.Hour, movieAllHandler(ms, "gif")))
 		router.GET("/movies/:name/search.html",
@@ -278,6 +280,23 @@ func movieHandler(ms []movies.Movie, format string) func(c *gin.Context) {
 			}
 
 			c.Data(http.StatusOK, "image/gif", gif)
+			return
+		case "webm":
+			nframes := 50
+			if c.Query("frames") != "" {
+				i, err := strconv.Atoi(c.Query("frames"))
+				if err == nil && nframes <= 200 {
+					nframes = i
+				}
+			}
+
+			webm, err := movie.WebM(at, nframes*25/framesPerSecond, 25)
+			if err != nil {
+				c.Data(http.StatusInternalServerError, "video/webm", []byte{})
+				return
+			}
+
+			c.Data(http.StatusOK, "video/webm", webm)
 			return
 		}
 

--- a/movies/ffmpeg/ffmpeg.go
+++ b/movies/ffmpeg/ffmpeg.go
@@ -19,7 +19,7 @@ var Debug = false
 func Duration(video string) (time.Duration, error) {
 	// from https://superuser.com/questions/650291/how-to-get-video-duration-in-seconds
 	out, err := execCommand(
-		fmt.Sprintf(`ffmpeg -i '%s' 2>&1 | grep "Duration"| cut -d ' ' -f 4 | sed s/,// | sed 's@\..*@@g' | awk '{ split($1, A, ":"); split(A[3], B, "."); print 3600*A[1] + 60*A[2] + B[1] }'`, video))
+		fmt.Sprintf(`ffmpeg -i '%s' 2>&1 | awk -F[:.] '/Duration:/ {print $2*3600+$3*60+$4}'`, video))
 	if err != nil {
 		return 0, err
 	}

--- a/movies/ffmpeg/ffmpeg.go
+++ b/movies/ffmpeg/ffmpeg.go
@@ -41,7 +41,11 @@ func Capture(video string, after time.Duration, width, height int) (image.Image,
 }
 
 func Captures(video string, after time.Duration, width, height, n int) ([]image.Image, error) {
-	tmp := "/tmp/" + uuid.NewV4().String() + "-%04d.jpg"
+	uuid, err := uuid.NewV4()
+	if err != nil {
+		return nil, err
+	}
+	tmp := "/tmp/" + uuid.String() + "-%04d.jpg"
 	fmt.Println("saving", n, tmp)
 	defer func() {
 		for i := 0; i < n; i++ {
@@ -54,7 +58,7 @@ func Captures(video string, after time.Duration, width, height, n int) ([]image.
 		resolutionFlag = fmt.Sprintf("-s %dx%d", width, height)
 	}
 
-	_, err := execCommand(
+	_, err = execCommand(
 		fmt.Sprintf(`ffmpeg -y -ss %f -i '%s' -vframes %d -r 5 %s %s`, after.Seconds(), video, n, resolutionFlag, tmp))
 	if err != nil {
 		return nil, err
@@ -77,7 +81,11 @@ func Captures(video string, after time.Duration, width, height, n int) ([]image.
 }
 
 func GIFCaptures(video string, after time.Duration, width, height, n, framesPerSecond int) ([]*image.Paletted, error) {
-	tmp := "/tmp/" + uuid.NewV4().String() + ".gif"
+	uuid, err := uuid.NewV4()
+	if err != nil {
+		return nil, err
+	}
+	tmp := "/tmp/" + uuid.String() + ".gif"
 	fmt.Println("saving", n, tmp)
 	defer os.Remove(tmp)
 
@@ -86,7 +94,7 @@ func GIFCaptures(video string, after time.Duration, width, height, n, framesPerS
 		resolutionFlag = fmt.Sprintf("-s %dx%d", width, height)
 	}
 
-	_, err := execCommand(
+	_, err = execCommand(
 		fmt.Sprintf(`ffmpeg -y -ss %f -i '%s' -vframes %d -r %d %s %s`,
 			after.Seconds(), video, n, framesPerSecond, resolutionFlag, tmp))
 	if err != nil {

--- a/movies/local.go
+++ b/movies/local.go
@@ -69,6 +69,10 @@ func (l *Local) Frames(at time.Duration, n, framesPerSecond int) []image.Image {
 	return out
 }
 
+func (l *Local) WebM(at time.Duration, n, framesPerSecond int) ([]byte, error) {
+	return ffmpeg.WebM(l.video, at, l.width, l.height, n, framesPerSecond)
+}
+
 func (l *Local) Caption(at time.Duration) string {
 	return l.captions.At(at)
 }

--- a/movies/movies.go
+++ b/movies/movies.go
@@ -10,6 +10,7 @@ type Movie interface {
 	Duration() time.Duration
 	Frame(at time.Duration) image.Image
 	Frames(at time.Duration, n, framesPerSecond int) []image.Image
+	WebM(at time.Duration, n, framesPerSecond int) ([]byte, error)
 	Caption(at time.Duration) string
 	CaptionBetween(start, end time.Duration) []Caption
 }


### PR DESCRIPTION
Because we want high def movie extracts. Choice of webm requires ffmpeg to be built with libvpx. If it's too much hassle we can change to mp4.

Currently there's no subtitles because ffmpeg libass' integration (lib doing the subtitles), doesn't allow to skip to a specific part like it does with video. One fix would be to generate a srt file with relevant subtitles and properly time shifted. Given the current state of the code, I think it's quite feasable.

I explicitly removed audio from extracts. Without audio, they can be embed into web pages (via the <video> tag) and with proper attributes (autoplay, loop) they will be played on page load. Current browsers tend to forbid that behavior for videos with audio due to abuse by ads.

Huge fan of your project Gildas ❤️ 