### PR TITLE
add subtitles for webm

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 				captions = subtitles
 			}
 
-			l, err := movies.NewLocal(name, mc.Movie, captions, 1024/2, 576/2)
+			l, err := movies.NewLocal(name, mc.Movie, mc.Subtitles, captions, 1024/2, 576/2)
 			if err != nil {
 				fmt.Println(err)
 				return

--- a/movies/local.go
+++ b/movies/local.go
@@ -12,6 +12,7 @@ import (
 type Local struct {
 	name          string
 	video         string
+	sub           string
 	captions      Captions
 	width, height int
 
@@ -23,7 +24,7 @@ type Captions interface {
 	Between(start, end time.Duration) []Caption
 }
 
-func NewLocal(name, video string, captions Captions, width, height int) (*Local, error) {
+func NewLocal(name, video, sub string, captions Captions, width, height int) (*Local, error) {
 	d, err := ffmpeg.Duration(video)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not inspect movie file %q", video)
@@ -32,6 +33,7 @@ func NewLocal(name, video string, captions Captions, width, height int) (*Local,
 	return &Local{
 		name:     name,
 		video:    video,
+		sub:      sub,
 		captions: captions,
 		width:    width,
 		height:   height,
@@ -70,7 +72,7 @@ func (l *Local) Frames(at time.Duration, n, framesPerSecond int) []image.Image {
 }
 
 func (l *Local) WebM(at time.Duration, n, framesPerSecond int) ([]byte, error) {
-	return ffmpeg.WebM(l.video, at, l.width, l.height, n, framesPerSecond)
+	return ffmpeg.WebM(l.video, l.sub, at, l.width, l.height, n, framesPerSecond)
 }
 
 func (l *Local) Caption(at time.Duration) string {

--- a/movies/local_test.go
+++ b/movies/local_test.go
@@ -15,7 +15,7 @@ func init() {
 }
 
 func TestLocal(t *testing.T) {
-	l, err := NewLocal("test", os.Getenv("FFMPEG_TEST_MOVIE"), nil, 1024, 576)
+	l, err := NewLocal("test", os.Getenv("FFMPEG_TEST_MOVIE"), "", nil, 1024, 576)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1*time.Hour+11*time.Minute+46*time.Second, l.Duration())


### PR DESCRIPTION
Not sure if fontsdir is needed. More options to how the subtitles are rendered are available, so far I only picked font size from gif rendering. In the end it was feasible with ffmpeg without the need to timeshift subtitles by hand.